### PR TITLE
feat(zsh): add git clean aliases

### DIFF
--- a/.../self/data/profile/zsh/aliases
+++ b/.../self/data/profile/zsh/aliases
@@ -32,10 +32,10 @@ alias qd!="git reset --mixed"
 alias qdd="git checkout --patch"
 # Query Delete2 (batch; resets worktree)
 alias qdd!="git reset --hard"
-# Query2 Delete2 (TODO: git clean)
-alias qddq="git"
-# Query2 Delete2 (TODO: git clean)
-alias qddq!="git"
+# Query2 Delete2 (interactive; cleanup untracked files)
+alias qddq="git clean -i"
+# Query2 Delete2 (force; cleanup untracked files)
+alias qddq!="git clean -fd"
 # Query State Quietly (last update)
 alias qsq="git\${=_GIT_DIFF_ARGS} show --stat"
 # Query State (last update; verbose)


### PR DESCRIPTION
## Summary
- add qddq alias for interactive `git clean`
- add qddq! alias for forceful `git clean`

## Testing
- `shellcheck .../self/data/profile/zsh/aliases` *(fails: command not found)*
- `zsh -n .../self/data/profile/zsh/aliases` *(fails: command not found)*
- `bash -n .../self/data/profile/zsh/aliases`


------
https://chatgpt.com/codex/tasks/task_e_68b7c36db4388321a8632b090afc474f